### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# denowiki
+Experiment to create a Deno based implementation of Federated Wiki
+
+## Install
+
+Get the prerequsites
+```
+brew install deno
+git clone git@github.com:WardCunningham/denowiki.git
+```
+Build and run from denowiki directory
+```
+deno --allow-net --allow-read index.ts


### PR DESCRIPTION
Add install and build instructions in case we forget.

(I may have made this more complicated than need be as this is the developer install. Can we launch a serviceable version of denowiki with one line letting it fetch the code from github?)