### PR TITLE
server-side start, stop & step

### DIFF
--- a/client/process-step.mjs
+++ b/client/process-step.mjs
@@ -88,12 +88,11 @@ class ProcessStep extends HTMLElement {
         }
         this.button.disabled = true
         this.state = "waiting"
-        let response = await fetch(`${href}?action=${action}`)
-        let status = await response.text()
+        let response = await fetch(`${href}?action=${action}`).then(res=>res.json())
         this.button.disabled = false
-        this.state = "step"
-        this.status = status
-        console.log(this, status)
+        this.state = response.running ? 'stop' : 'start'
+        this.status = response.status
+        console.log(this, response)
     }
 }
 registerPlugin("process-step", ProcessStep)

--- a/scrapetest.sh
+++ b/scrapetest.sh
@@ -1,0 +1,27 @@
+echo we start running full speed
+curl -s 'http://scrape.localtest.me:8000/button?action=start' | jq .running; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=state' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=state' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=state' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=state' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=state' | jq .status; sleep 2
+
+echo we stop running full stop
+curl -s 'http://scrape.localtest.me:8000/button?action=stop' | jq .running; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=state' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=state' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=state' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=state' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=state' | jq .status; sleep 2
+
+echo we single step for ten steps
+curl -s 'http://scrape.localtest.me:8000/button?action=step' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=step' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=step' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=step' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=step' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=step' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=step' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=step' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=step' | jq .status; sleep 2
+curl -s 'http://scrape.localtest.me:8000/button?action=step' | jq .status; sleep 2


### PR DESCRIPTION
The client-side is not quite right yet.

Here we replace the client with a script that hits the server three different ways with curl commands.

![image](https://user-images.githubusercontent.com/12127/76056420-5905b480-5f2b-11ea-9b9e-85a3e40535a9.png)

This script runs a new command every two seconds. The behavior server-side depends what action sequence the script chooses. The script runs in three phases:

- start, poll watching the server run
- stop, poll confirming that the server stopped
- step, and see that we are advancing one step at a time