### PR TITLE
correct logic for new and completed computations

### DIFF
--- a/scrapetest.js
+++ b/scrapetest.js
@@ -1,3 +1,4 @@
 let t0 = Date.now()
-let r = await fetch(`http://scrape.localtest.me:8000/button?action=${Deno.args[0]||'state'}`).then(r=>r.json())
-console.log(r,Date.now()-t0, 'ms')
+let action = Deno.args[0]||'state'
+let url = `http://scrape.localtest.me:8000/button?action=${action}`
+console.log(action, '⇒', await fetch(url).then(r=>r.json()), Date.now()-t0, 'ms')

--- a/scrapetest.sh
+++ b/scrapetest.sh
@@ -1,27 +1,50 @@
-echo; echo we start running full speed
-deno --allow-net scrapetest.js start; sleep 2
-deno --allow-net scrapetest.js state; sleep 2
-deno --allow-net scrapetest.js state; sleep 2
-deno --allow-net scrapetest.js state; sleep 2
-deno --allow-net scrapetest.js state; sleep 2
-deno --allow-net scrapetest.js state; sleep 2
+echo; echo inquire as to intial state
+deno --allow-net scrapetest.js state; sleep 1
 
-echo; echo we stop status full stop
-deno --allow-net scrapetest.js stop;  sleep 2
-deno --allow-net scrapetest.js state; sleep 2
-deno --allow-net scrapetest.js state; sleep 2
-deno --allow-net scrapetest.js state; sleep 2
-deno --allow-net scrapetest.js state; sleep 2
-deno --allow-net scrapetest.js state; sleep 2
+echo; echo start running full speed
+deno --allow-net scrapetest.js start; sleep 1
+deno --allow-net scrapetest.js state; sleep 1
+deno --allow-net scrapetest.js state; sleep 1
+deno --allow-net scrapetest.js state; sleep 1
+deno --allow-net scrapetest.js state; sleep 1
+deno --allow-net scrapetest.js state; sleep 1
 
-echo; echo we single step for ten steps
-deno --allow-net scrapetest.js step; sleep 2
-deno --allow-net scrapetest.js step; sleep 2
-deno --allow-net scrapetest.js step; sleep 2
-deno --allow-net scrapetest.js step; sleep 2
-deno --allow-net scrapetest.js step; sleep 2
-deno --allow-net scrapetest.js step; sleep 2
-deno --allow-net scrapetest.js step; sleep 2
-deno --allow-net scrapetest.js step; sleep 2
-deno --allow-net scrapetest.js step; sleep 2
-deno --allow-net scrapetest.js step; sleep 2
+echo; echo stop then status five times
+deno --allow-net scrapetest.js stop;  sleep 1
+deno --allow-net scrapetest.js state; sleep 1
+deno --allow-net scrapetest.js state; sleep 1
+deno --allow-net scrapetest.js state; sleep 1
+deno --allow-net scrapetest.js state; sleep 1
+deno --allow-net scrapetest.js state; sleep 1
+
+echo; echo run again maybe to completion
+deno --allow-net scrapetest.js start; sleep 1
+deno --allow-net scrapetest.js state; sleep 1
+deno --allow-net scrapetest.js state; sleep 1
+deno --allow-net scrapetest.js state; sleep 1
+deno --allow-net scrapetest.js state; sleep 1
+deno --allow-net scrapetest.js state; sleep 1
+
+echo; echo start then stop five times
+deno --allow-net scrapetest.js start; sleep 1
+deno --allow-net scrapetest.js stop; sleep 1
+deno --allow-net scrapetest.js start; sleep 1
+deno --allow-net scrapetest.js stop; sleep 1
+deno --allow-net scrapetest.js start; sleep 1
+deno --allow-net scrapetest.js stop; sleep 1
+deno --allow-net scrapetest.js start; sleep 1
+deno --allow-net scrapetest.js stop; sleep 1
+deno --allow-net scrapetest.js start; sleep 1
+deno --allow-net scrapetest.js stop; sleep 1
+
+echo; echo single step for ten steps
+deno --allow-net scrapetest.js step; sleep 1
+deno --allow-net scrapetest.js step; sleep 1
+deno --allow-net scrapetest.js step; sleep 1
+deno --allow-net scrapetest.js step; sleep 1
+deno --allow-net scrapetest.js step; sleep 1
+deno --allow-net scrapetest.js step; sleep 1
+deno --allow-net scrapetest.js step; sleep 1
+deno --allow-net scrapetest.js step; sleep 1
+deno --allow-net scrapetest.js step; sleep 1
+deno --allow-net scrapetest.js step; sleep 1


### PR DESCRIPTION
I've revised the mock computation to not loop forever. Instead it resolves upon completion returning the elapsed runtime including starts and stops.

```
      run().then((dt) => {
        running=false;
        status=`complete in ${dt} seconds`
      });
```

I've modified the scrape test to run through more of these conditions. I still haven't synchronized with a single step completion so I put a sleep into the step handler to show that I can see the response time once it is working.

```
sh scrapetest.sh

inquire as to intial state
state ⇒ { running: false, waiting: false, status: "beginning" } 8 ms

start running full speed
start ⇒ { running: true, waiting: false, status: "outer at 1 1 1" } 6 ms
state ⇒ { running: true, waiting: false, status: "inner at 1 2 3" } 6 ms
state ⇒ { running: true, waiting: false, status: "inner at 1 4 4" } 6 ms
state ⇒ { running: true, waiting: false, status: "inner at 2 2 3" } 6 ms
state ⇒ { running: true, waiting: false, status: "inner at 2 4 2" } 6 ms
state ⇒ { running: true, waiting: false, status: "inner at 3 2 1" } 6 ms

stop then status five times
stop ⇒ { running: false, waiting: false, status: "inner at 3 4 1" } 6 ms
state ⇒ { running: false, waiting: true, status: "inner at 3 4 2" } 6 ms
state ⇒ { running: false, waiting: true, status: "inner at 3 4 2" } 6 ms
state ⇒ { running: false, waiting: true, status: "inner at 3 4 2" } 6 ms
state ⇒ { running: false, waiting: true, status: "inner at 3 4 2" } 6 ms
state ⇒ { running: false, waiting: true, status: "inner at 3 4 2" } 6 ms

run again maybe to completion
start ⇒ { running: true, waiting: false, status: "inner at 3 4 2" } 6 ms
state ⇒ { running: true, waiting: false, status: "middle at 4 2 5" } 6 ms
state ⇒ { running: true, waiting: false, status: "inner at 4 4 1" } 6 ms
state ⇒ { running: false, waiting: false, status: "complete in 14.895 seconds" } 6 ms
state ⇒ { running: false, waiting: false, status: "complete in 14.895 seconds" } 7 ms
state ⇒ { running: false, waiting: false, status: "complete in 14.895 seconds" } 6 ms

start then stop five times
start ⇒ { running: true, waiting: false, status: "outer at 1 5 5" } 7 ms
stop ⇒ { running: false, waiting: false, status: "inner at 1 2 4" } 6 ms
start ⇒ { running: true, waiting: false, status: "middle at 1 3 5" } 6 ms
stop ⇒ { running: false, waiting: false, status: "inner at 1 4 4" } 6 ms
start ⇒ { running: true, waiting: false, status: "outer at 2 5 5" } 6 ms
stop ⇒ { running: false, waiting: false, status: "inner at 2 2 4" } 6 ms
start ⇒ { running: true, waiting: false, status: "middle at 2 3 5" } 6 ms
stop ⇒ { running: false, waiting: false, status: "outer at 3 5 5" } 6 ms
start ⇒ { running: true, waiting: false, status: "middle at 3 1 5" } 6 ms
stop ⇒ { running: false, waiting: false, status: "middle at 3 3 5" } 6 ms

single step for ten steps
step ⇒ { running: false, waiting: false, status: "inner at 3 3 1" } 39 ms
step ⇒ { running: false, waiting: false, status: "inner at 3 3 2" } 43 ms
step ⇒ { running: false, waiting: false, status: "inner at 3 3 3" } 43 ms
step ⇒ { running: false, waiting: false, status: "inner at 3 3 4" } 42 ms
step ⇒ { running: false, waiting: false, status: "middle at 3 4 5" } 42 ms
step ⇒ { running: false, waiting: false, status: "inner at 3 4 1" } 43 ms
step ⇒ { running: false, waiting: false, status: "inner at 3 4 2" } 42 ms
step ⇒ { running: false, waiting: false, status: "inner at 3 4 3" } 42 ms
step ⇒ { running: false, waiting: false, status: "inner at 3 4 4" } 43 ms
step ⇒ { running: false, waiting: false, status: "outer at 4 5 5" } 43 ms
```