### PR TITLE
experiment with static pages in code

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -89,7 +89,7 @@ async function importMetaSite(path, host) {
     // Some sites will init their sitemap here
     // Others will do lengthy init processing
     // To wait or not to wait?
-    metaSite.init();
+    metaSite.init({site});
   }
   let targetHost = `${name}:${port}`;
   system.metaSites[targetHost] = metaSite;

--- a/meta-sites/metatext.localhost.js
+++ b/meta-sites/metatext.localhost.js
@@ -1,0 +1,81 @@
+const { stat } = Deno;
+export let metaPages = {};
+
+// function route(url:string, fn) {
+//   metaPages[url] = fn;
+// }
+
+let metaText = `
+Welcome Visitors
+
+  who: "[[DenoWiki]]",
+  what: "[[Region Scraper]]"
+
+Region Scraper
+
+  Here we supervise the ongoing scrape of the wiki federation.
+  We invision this as cooperating loops where sitemap fetches lead
+  to page fetches and these lead to more sitemap fetches.
+
+  See [[Stepping the Async Scrape]]
+
+  While developing this technology we focus first on a nested loop.
+  We have several versions of this where we explore different instrumentation strategies.
+
+  [[Mock Computation]]
+
+  [[Triple Controls]]
+
+Mock Computation
+
+  Here we start, stop and step a triple nested loop that counts iterations
+  until five of each, for 5 * 5 * 5 total iterations have completed.
+  See also [[Triple Controls]] of the same loop
+
+  process-step:
+    legend: "Simple Nested Loop",
+    href: "/simple"
+
+Triple Controls
+
+  Here we start, stop and step with distinct controls for each nesting level.
+
+  process-step:
+    legend: "Outer Nested Loop",
+    href: "/outer"
+
+  process-step:
+    legend: "Middle Nested Loop",
+    href: "/middle"
+
+  process-step:
+    legend: "Inner Nested Loop",
+    href: "/inner"`
+
+
+function asSlug(title) {
+  return title.replace(/\s/g, "-").replace(/[^A-Za-z0-9-]/g, "").toLowerCase();
+}
+
+function parse(sep, text, fn) {
+  let v = text.split(sep)
+  for(let i = 1; i<v.length; i+=2)
+    fn(v[i], v[i+1])
+}
+
+parse(/\n([A-Z][A-Za-z ]*)/g, metaText, (title, body) => {
+  let page = {title,story:[]}
+  parse(/(\n\n)/g, body, (blank, text) => {
+    let id = Math.floor(Math.random()*2**58).toString(36)
+    let m = text.match(/\s+([a-z-]+):/)
+    // if (m) {
+      // let p = JSON.parse(`{${text.replace(/\s+([a-z-]+):/,'')}}`)
+      // page.story.push(Object.assign({type:m[1],id},p))
+    // } else {
+      page.story.push({type:'paragraph',text,id})
+    // }
+  })
+  metaPages[`/${asSlug(title)}.json`] = async (req, site, _system) => {console.log(page); site.serveJson(req, page)}
+})
+
+

--- a/meta-sites/metatext.localhost.js
+++ b/meta-sites/metatext.localhost.js
@@ -1,11 +1,8 @@
 const { stat } = Deno;
 export let metaPages = {};
 
-// function route(url:string, fn) {
-//   metaPages[url] = fn;
-// }
-
-let metaText = `
+export async function init(opts) {
+    opts.site.pages(`
 Welcome Visitors
 
   Welcome to this [[DenoWiki]] Federated Wiki site.
@@ -63,30 +60,5 @@ Triple Controls
     legend: "Inner Nested Loop",
     href: "/inner"`
 
-
-function asSlug(title) {
-  return title.replace(/\s/g, "-").replace(/[^A-Za-z0-9-]/g, "").toLowerCase();
-}
-
-function parse(sep, text, fn) {
-  let v = text.split(sep)
-  for(let i = 1; i<v.length; i+=2)
-    fn(v[i], v[i+1])
-}
-
-parse(/\n([A-Z][A-Za-z ]*)/g, metaText, (title, body) => {
-  let page = {title,story:[]}
-  parse(/(\n\n\s*)/g, body, (blank, text) => {
-    let id = Math.floor(Math.random()*2**58).toString(36)
-    let m = text.match(/([a-z-]+):/)
-    if (m) {
-      let args = eval(`({${text.replace(/([a-z-]+):/,'')}})`)
-      page.story.push(Object.assign({type:m[1],id},args))
-    } else {
-      page.story.push({type:'paragraph',text,id})
-    }
-  })
-  metaPages[`/${asSlug(title)}.json`] = async (req, site, _system) => {site.serveJson(req, page)}
-})
-
+)}
 

--- a/meta-sites/metatext.localhost.js
+++ b/meta-sites/metatext.localhost.js
@@ -8,8 +8,19 @@ export let metaPages = {};
 let metaText = `
 Welcome Visitors
 
-  who: "[[DenoWiki]]",
-  what: "[[Region Scraper]]"
+  Welcome to this [[DenoWiki]] Federated Wiki site.
+  From this page you can find who we are and what we do.
+  New sites provide this information and then claim the site as their own.
+  You will need your own site to participate.
+
+  Pages about us.
+
+  [[Ward Cunningham]]
+
+  Pages where we do and share.
+
+  [[Region Scraper]]
+
 
 Region Scraper
 
@@ -65,17 +76,17 @@ function parse(sep, text, fn) {
 
 parse(/\n([A-Z][A-Za-z ]*)/g, metaText, (title, body) => {
   let page = {title,story:[]}
-  parse(/(\n\n)/g, body, (blank, text) => {
+  parse(/(\n\n\s*)/g, body, (blank, text) => {
     let id = Math.floor(Math.random()*2**58).toString(36)
-    let m = text.match(/\s+([a-z-]+):/)
-    // if (m) {
-      // let p = JSON.parse(`{${text.replace(/\s+([a-z-]+):/,'')}}`)
-      // page.story.push(Object.assign({type:m[1],id},p))
-    // } else {
+    let m = text.match(/([a-z-]+):/)
+    if (m) {
+      let args = eval(`({${text.replace(/([a-z-]+):/,'')}})`)
+      page.story.push(Object.assign({type:m[1],id},args))
+    } else {
       page.story.push({type:'paragraph',text,id})
-    // }
+    }
   })
-  metaPages[`/${asSlug(title)}.json`] = async (req, site, _system) => {console.log(page); site.serveJson(req, page)}
+  metaPages[`/${asSlug(title)}.json`] = async (req, site, _system) => {site.serveJson(req, page)}
 })
 
 

--- a/meta-sites/scrape.localhost.ts
+++ b/meta-sites/scrape.localhost.ts
@@ -13,54 +13,66 @@ function route(url, fn) {
   metaPages[url] = fn;
 }
 
-route("/welcome-visitors.json", async (req, site, _system) => {
-  site.serveJson(req, site.welcomePage("[[DenoWiki]]", "[[Region Scraper]]"));
-});
+export async function init(opts) {
+    opts.site.pages(`
+Welcome Visitors
 
-route("/region-scraper.json", async (req, site, _system) => {
-  site.serveJson(req, site.page("Region Scraper", [
-    site.paragraph(
-      `Here we supervise the ongoing scrape of the wiki federation.
-      We invision this as cooperating loops where sitemap fetches lead
-      to page fetches and these lead to more sitemap fetches.`
-    ),
-    site.paragraph(
-      `See [[Stepping the Async Scrape]]`
-    ),
-    site.paragraph(
-      `While developing this technology we focus first on a nested loop.
-      We have several versions of this where we explore different instrumentation strategies.`
-    ),
-    site.paragraph(
-      `[[Mock Computation]]`
-    ),
-    site.paragraph(
-      `[[Triple Controls]]`
-    ),
-  ]));
-});
+  Welcome to this [[DenoWiki]] Federated Wiki site.
+  From this page you can find who we are and what we do.
+  New sites provide this information and then claim the site as their own.
+  You will need your own site to participate.
 
-route("/mock-computation.json", async (req, site, _system) => {
-  site.serveJson(req, site.page("Mock Computation", [
-    site.paragraph(
-      `Here we start, stop and step a triple nested loop that counts iterations
-      until five of each, for 5 * 5 * 5 total iterations have completed.
-      See also [[Triple Controls]] of the same loop`
-    ),
-    site.item("process-step", { legend: "Simple Nested Loop", href: "/simple" })
-  ]));
-});
+  Pages about us.
 
-route("/triple-controls.json", async (req, site, _system) => {
-  site.serveJson(req, site.page("Triple Controls", [
-    site.paragraph(
-      `Here we start, stop and step with distinct controls for each nesting level.`
-    ),
-    site.item("process-step", { legend: "Outer Nested Loop", href: "/outer" }),
-    site.item("process-step", { legend: "Middle Nested Loop", href: "/middle" }),
-    site.item("process-step", { legend: "Inner Nested Loop", href: "/inner" })
-  ]));
-});
+  [[Ward Cunningham]]
+
+  Pages where we do and share.
+
+  [[Region Scraper]]
+
+
+Region Scraper
+
+  Here we supervise the ongoing scrape of the wiki federation.
+  We invision this as cooperating loops where sitemap fetches lead
+  to page fetches and these lead to more sitemap fetches.
+
+  See [[Stepping the Async Scrape]]
+
+  While developing this technology we focus first on a nested loop.
+  We have several versions of this where we explore different instrumentation strategies.
+
+  [[Mock Computation]]
+
+  [[Triple Controls]]
+
+Mock Computation
+
+  Here we start, stop and step a triple nested loop that counts iterations
+  until five of each, for 5 * 5 * 5 total iterations have completed.
+  See also [[Triple Controls]] of the same loop
+
+  process-step:
+    legend: "Simple Nested Loop",
+    href: "/simple"
+
+Triple Controls
+
+  Here we start, stop and step with distinct controls for each nesting level.
+
+  process-step:
+    legend: "Outer Nested Loop",
+    href: "/outer"
+
+  process-step:
+    legend: "Middle Nested Loop",
+    href: "/middle"
+
+  process-step:
+    legend: "Inner Nested Loop",
+    href: "/inner"`
+
+)}
 
 
 // S I M P L E   M O C K   C O M P U T A T I O N

--- a/meta-sites/static.localhost.ts
+++ b/meta-sites/static.localhost.ts
@@ -61,7 +61,8 @@ export function siteMap() {
     return _siteMap
 }
 
-export async function init(siteName, system) {
+export async function init(opts) {
+    const {siteName, system} = opts
     // Uncomment to register all existing wikis
     return
     if (siteName.indexOf("static.localhost") == -1) {

--- a/site.ts
+++ b/site.ts
@@ -98,6 +98,35 @@ export async function serve(req: ServerRequest, site, system) {
   }
 }
 
+export function pages(metaText) {
+
+  function asSlug(title) {
+    return title.replace(/\s/g, "-").replace(/[^A-Za-z0-9-]/g, "").toLowerCase();
+  }
+
+  function parse(sep, text, fn) {
+    let v = text.split(sep)
+    for(let i = 1; i<v.length; i+=2)
+      fn(v[i], v[i+1])
+  }
+
+  parse(/\n([A-Z][A-Za-z ]*)/g, metaText, (title, body) => {
+    let page = {title,story:[]}
+    parse(/(\n\n\s*)/g, body, (blank, text) => {
+      let id = itemId()
+      let m = text.match(/([a-z-]+):/)
+      if (m) {
+        let args = eval(`({${text.replace(/([a-z-]+):/,'')}})`)
+        page.story.push(Object.assign({type:m[1],id},args))
+      } else {
+        page.story.push({type:'paragraph',text,id})
+      }
+    })
+    metaPages[`/${asSlug(title)}.json`] = async (req, site, _system) => {site.serveJson(req, page)}
+  })
+
+}
+
 export function page(title, items) {
   return {
     title,


### PR DESCRIPTION
see `http://metatext.localtest.me:8000/index.html` for static pages in code.

![image](https://user-images.githubusercontent.com/12127/76189130-24963080-6197-11ea-8982-409878639f56.png)

This might be an approach for including navigation and documentation in a meta-site.

(I almost got the arbitrary type item generator working but had to call it a night.)