### PR TITLE
Update Dockerfile for deno 1.0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ ADD . /seran-wiki
 # RUN deno fetch main.ts
 
 # These are passed as deno arguments when run with docker:
-ENTRYPOINT ["deno", "-c", "tsconfig.json", "--importmap=import_map.json", "--allow-net", "--allow-read", "--allow-write", "--allow-env", "--allow-run", "./server/seran.ts", "--allow-disclosure"]
+ENTRYPOINT ["deno", "run", "-c", "tsconfig.json", "--unstable", "--importmap=import_map.json", "--allow-net", "--allow-read", "--allow-write", "--allow-env", "--allow-run", "./server/seran.ts", "--allow-disclosure"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hayd/alpine-deno:1.0.0
+FROM hayd/alpine-deno:1.0.5
 
 EXPOSE 8000
 

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
     "imports": {
-        "std/": "https://deno.land/std@v0.50.0/",
+        "std/": "https://deno.land/std@v0.55.0/",
         "seran/": "./server/"
     }
 }


### PR DESCRIPTION
Note: our recommended command line parameters appear in three places for three different systems.

* unix
* windows
* docker

There is some reason why we have two docker files and can't just invoke `sh run.sh` but I have forgotten them now.